### PR TITLE
Fixed single document updating.

### DIFF
--- a/Model/Behavior/SearchableBehavior.php
+++ b/Model/Behavior/SearchableBehavior.php
@@ -402,7 +402,7 @@ class SearchableBehavior extends ModelBehavior {
 		$this->progress($Model, '(store)' . "\n");
 
 		if ($docCount == 1) {
-			$res = $this->execute($Model, 'PUT', '_bulk', $doc);
+			$res = $this->execute($Model, 'PUT', $meta['_id'], $doc);
 		} else {
 			$res = $this->execute($Model, 'PUT', '_bulk', $commands, array('prefix' => '', ));
 		}


### PR DESCRIPTION
The _bulk endpoint doesn't support updating of single documents, the document's ID should be used as an end point instead.

Signed-off-by: Justin Kaufman jkaufman@lodgeistics.net
